### PR TITLE
Fix ride termination on mqtt message

### DIFF
--- a/Date/MqttService.cs
+++ b/Date/MqttService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 using System.Threading.Tasks;
 using CarboxBackend.Models;
@@ -30,7 +30,7 @@ namespace CarboxBackend.Services
             _mqttClient = mqttFactory.CreateMqttClient();
 
             _mqttClientOptions = new MqttClientOptionsBuilder()
-                .WithClientId("MQTTServer")
+                .WithClientId($"MQTTServer-{_instanceId}")
                 .WithTcpServer("test.mosquitto.org", 1883) // Eclipse Mosquitto public broker
                 .Build();
 
@@ -66,10 +66,11 @@ namespace CarboxBackend.Services
 
                 var subscribeOptions = new MqttClientSubscribeOptionsBuilder()
                     .WithTopicFilter(f => f.WithTopic("carbox/data/#"))
+                    .WithTopicFilter(f => f.WithTopic("carbox/ride/+/end"))
                     .Build();
 
                 await _mqttClient.SubscribeAsync(subscribeOptions, stoppingToken);
-                Console.WriteLine("Subscribed to topic: carbox/data/#");
+                Console.WriteLine("Subscribed to topics: carbox/data/# and carbox/ride/+/end");
 
                 while (!stoppingToken.IsCancellationRequested)
                 {
@@ -102,26 +103,50 @@ namespace CarboxBackend.Services
 
                 var topic = e.ApplicationMessage.Topic;
                 var payload = Encoding.UTF8.GetString(e.ApplicationMessage.Payload.ToArray());
-                Console.WriteLine($"Received message from topic '{topic}': {payload}");
+                Console.WriteLine($"[MqttService {_instanceId}] Received message from topic '{topic}': {payload}");
 
                 // Handle end ride message
                 if (topic.StartsWith("carbox/ride/") && topic.EndsWith("/end"))
                 {
+                    Console.WriteLine($"[MqttService {_instanceId}] Processing end ride message for topic: {topic}");
                     // Extract rideId from topic
                     var parts = topic.Split('/');
+                    Console.WriteLine($"[MqttService {_instanceId}] Topic parts: {string.Join(", ", parts)}");
                     if (parts.Length >= 4)
                     {
                         var rideIdStr = parts[2];
+                        Console.WriteLine($"[MqttService {_instanceId}] Extracted ride ID string: {rideIdStr}");
                         if (int.TryParse(rideIdStr, out int rideId))
                         {
+                            Console.WriteLine($"[MqttService {_instanceId}] Parsed ride ID: {rideId}");
                             var rideOrder = await rideOrderRepository.GetRideByIdAsync(rideId);
-                            if (rideOrder != null && rideOrder.Status != RideOrderStatus.Completed)
+                            if (rideOrder != null)
                             {
-                                rideOrder.Status = RideOrderStatus.Completed;
-                                await rideOrderRepository.UpdateRideAsync(rideOrder);
-                                Console.WriteLine($"Ride {rideId} marked as completed due to end ride MQTT message.");
+                                Console.WriteLine($"[MqttService {_instanceId}] Found ride order: ID={rideOrder.Id}, Status={rideOrder.Status}");
+                                if (rideOrder.Status != RideOrderStatus.Completed)
+                                {
+                                    rideOrder.Status = RideOrderStatus.Completed;
+                                    await rideOrderRepository.UpdateRideAsync(rideOrder);
+                                    Console.WriteLine($"[MqttService {_instanceId}] Ride {rideId} marked as completed due to end ride MQTT message.");
+                                }
+                                else
+                                {
+                                    Console.WriteLine($"[MqttService {_instanceId}] Ride {rideId} was already completed.");
+                                }
+                            }
+                            else
+                            {
+                                Console.WriteLine($"[MqttService {_instanceId}] No ride order found with ID: {rideId}");
                             }
                         }
+                        else
+                        {
+                            Console.WriteLine($"[MqttService {_instanceId}] Failed to parse ride ID from string: {rideIdStr}");
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine($"[MqttService {_instanceId}] Invalid topic format. Expected at least 4 parts, got {parts.Length}");
                     }
                     return;
                 }


### PR DESCRIPTION
Enable MQTT service to end rides via wildcard topic subscription and prevent client ID session takeovers.

---
<a href="https://cursor.com/background-agent?bcId=bc-cdfc27cb-7082-459d-982c-03b0afbde002">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cdfc27cb-7082-459d-982c-03b0afbde002">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

